### PR TITLE
Some changes to animals and mood keywords

### DIFF
--- a/api/images.go
+++ b/api/images.go
@@ -15,27 +15,31 @@ var apiKey = os.Getenv("FLICKR_API_KEY")
 
 var animals = []string{
 	"monkey",
-	"dog",
 	"cat",
-	"squirrel",
-	"bird",
+	"dog",
+	"wolf",
+	"fox",
 	"gorilla",
-	"penguin",
-	"cow",
-	"chicken",
 	"lemur",
+	"lion",
+	"tiger",
+	"owl",
+	"otter",
+	"bear",
+	"polar bear",
+	"hedgehog",
 }
 
 var emotions = []string{
 	"happy",
 	"sad",
-	"funny",
-	"angry",
-	"eating",
+	"", // neutral
+	"silly",
+	"feeding",
 	"sleeping",
-	"crazy",
-	"laughing",
-	"yawning",
+	"surprised",
+	"jumping",
+	"mouth open",
 }
 
 type RawPhotosResponse struct {


### PR DESCRIPTION
My line of thinking behind this is that certain animals are more emotive than others. A chicken doesn't convey emotion through an image very well, whereas a bear does. Hedgehogs were just put there for a certain team.  I also did some experimentation with various keywords and trying to get results and this is what I came up with. As an example, the word "eating" can be construed as "eating animal x" rather than "animal x eating", which is why I feel "feeding" can be a slightly more effective choice. 

Idk, maybe you should keep the moods as they are, or maybe when someone adds query params then we won't need to worry about this.

feel free to change how you like